### PR TITLE
feature-expand-a-branch-element

### DIFF
--- a/jquery.sapling.js
+++ b/jquery.sapling.js
@@ -77,6 +77,11 @@
 			expand($element.find('.sapling-item'));
 		};
 
+		plugin.expandElement = function(element) {
+			expand($element.find(element));
+			expand($(element).parents());
+		};		
+		
 		plugin.collapse = function() {
 			collapse($element.find('.sapling-expanded'));
 		};


### PR DESCRIPTION
Added the feature to expand only the element you select. 

Example of use. Having this list:

```
<ul id="myList">
    <li>This is first item
        <ul>
            <li id="subItem1">sub item 1</li>
            <li id="subItem2">sub item 2</li>
        </ul>
    </li>
    <li>This is second item
        <ul>
            <li id="subItem3">sub item 3</li>
            <li id="subItem4">sub item 4</li>
        </ul>
    </li>
</ul>
```

You can only expand the second branch with this:

`$('#myList').data('sapling').expandElement('#subItem4');`